### PR TITLE
Optimized version for possible to update without merge or destroy local config and better debugging posibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+update_config.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 update_config.php
+ctupdate.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /.idea
-update_config.php
+config.php
 ctupdate.lock

--- a/README.md
+++ b/README.md
@@ -23,9 +23,23 @@ Bei Fragen stehen wir gerne zur Verfügung! :)
 
 Vor dem erstmaligen Aufrufen der `update.php` müsst Ihr einen Hash für euer gewähltes Passwort erstellen.
 Dafür zuerst durch den Aufruf von <https://churchtools_domain.xyz/createHash.php?EUER_PASSWORT> einen Passwort-Hash erzeugen!
+
+### Configuration im File
 Danach müsst ihr den dort erstellten Hash in der `update.php` bei `define('HASH', 'PUT IN YOUR OWN HASH HERE');` eintragen.
 Wenn ihr jetzt noch bei `define('SEAFILE_DIR', '/d/xyz1234567/');` den Pfad auf die Stelle anpasst, bei der ihr die ChruchTools-Updates herunter ladet, ist das Skript einsatzbereit!
 (Ihr bekommt bei Updates per E-Mail einen Link zu einer SeaFile-Seite, die i.d.R. so aussieht: https://seafile.churchtools.de/d/xyz1234567/, kopiert davon einfach den hinteren Teil!) 
+
+### Configuration mit separatem File
+Alternativ könnt ihr auch die Daten in eine extra Daten `update_config.php` im selben Verzeichnis packen, dann kann man ohne Probleme auch den Code des Updaters updaten:
+```php
+<?php
+// Put in your own password hash here
+define('HASH', 'PUT IN YOUR OWN HASH HERE');
+// Modify to correct seafile server URL here
+define('SEAFILE_DIR', '/d/xyz1234567/');
+// Should be fine, except if JMR decides to change the location of the SeaFile server... ;)
+define('SEAFILE_URL', 'https://seafile.churchtools.de/' . SEAFILE_DIR);
+```
 
 Nun das Update-Skript im Root-Verzeichnis der ChurchTools Installation (neben `index.php, system, files, etc.`) ablegen und per Cronejob einmal am Tag (z.B. bei uns 4:00 Uhr) so aufrufen:
 <https://churchtools_domain.xyz/update.php?EUER_PASSWORT>

--- a/README.md
+++ b/README.md
@@ -20,38 +20,54 @@ Folgender **Funktionsumfang** ist in unserem Skript momentan enthalten:
 Bei Fragen stehen wir gerne zur Verfügung! :)
 
 ## Installation
+Hiermit wird ein `update` Verzeichnis in eurem Curchtools verzeichnis angelegt welches den Updater und die von euch zu erstellende Konfigurationsdatei enthält und ganz einfach geupdated werden kann.
+```bash
+cd CHURCHTOOLS_DIR
+git clone https://github.com/karl007/CT_AutoUpdater.git ./update
+```
 
-Vor dem erstmaligen Aufrufen der `update.php` müsst Ihr einen Hash für euer gewähltes Passwort erstellen.
-Dafür zuerst durch den Aufruf von <https://churchtools_domain.xyz/createHash.php?EUER_PASSWORT> einen Passwort-Hash erzeugen!
+## Update
+```bash
+cd CHURCHTOOLS_DIR/update
+git stash -u # ggf lokal gemachte änderungen werden als stash vorm überschreiben gespeichert
+git pull -v # holt die letzte Version vom Server
+git reset --hard # ersetzt alle lokalen files mit denen vom Server - die config.php ist hier nicht betroffen
+```
 
-### Configuration im File
-Danach müsst ihr den dort erstellten Hash in der `update.php` bei `define('HASH', 'PUT IN YOUR OWN HASH HERE');` eintragen.
-Wenn ihr jetzt noch bei `define('SEAFILE_DIR', '/d/xyz1234567/');` den Pfad auf die Stelle anpasst, bei der ihr die ChruchTools-Updates herunter ladet, ist das Skript einsatzbereit!
-(Ihr bekommt bei Updates per E-Mail einen Link zu einer SeaFile-Seite, die i.d.R. so aussieht: https://seafile.churchtools.de/d/xyz1234567/, kopiert davon einfach den hinteren Teil!) 
+## Configuration
+Vor dem ersten Update müsst Ihr einen Hash für euer gewähltes Passwort erstellen.
+Dafür zuerst durch den Aufruf von <https://churchtools_domain.xyz/update/?EUER_PASSWORT> einen Passwort-Hash erzeugen!
 
-### Configuration mit separatem File
-Alternativ könnt ihr auch die Daten in eine extra Daten `update_config.php` im selben Verzeichnis packen, dann kann man ohne Probleme auch den Code des Updaters updaten. `xyz1234567` müsst ihr jeweils mit dem Teil aus dem Link aus
-eurer Email ersetzen (Ihr bekommt bei Updates per E-Mail einen Link zu einer SeaFile-Seite, die i.d.R. so aussieht: https://seafile.churchtools.de/d/xyz1234567/, kopiert davon einfach den hinteren Teil zwischen den beiden `/`!) 
+Den Inhalt der bei diesem Aufruf angezeigt wird als `update/config.php` speichern und noch bei `define('SEAFILE_DIR', 'd/xyz1234567/');` und `define('SEAFILE_JSON_PATH', 'api/v2.1/share-links/xyz1234567/dirents');` den  Teil `xyz1234567` anpasst, bei der ihr die ChruchTools-Updates herunter ladet, ist das Skript einsatzbereit!
+(Ihr bekommt bei Updates per E-Mail einen Link zu einer SeaFile-Seite, die i.d.R. so aussieht: https://seafile.churchtools.de/d/xyz1234567/, verwendet davon einfach den hinteren Teil!)
 
+### Push
+Defaultmäßig ist Push deaktiviert, kann aber über die defines am beginn der `push.inc.php` eingerichtet und über das `define('ENABLE_PUSH', false);` aktiviert werden.
 
-**update_config.php:**
+**config.php:** (aktivierte Einträge sind Pflicht und müssen passen, die auskommentierten optional)
 ```php
 <?php
 // Put in your own password hash here
 define('HASH', 'PUT IN YOUR OWN HASH HERE');
 // Modify to correct seafile server URL here - end with slash
 define('SEAFILE_DIR', 'd/xyz1234567/');
-// Should be fine, except if JMR decides to change the location of the SeaFile server... ;) - end with slash
-define('SEAFILE_HOST', 'https://seafile.churchtools.de/');
 // JsonPath to the file containing the file list
 define('SEAFILE_JSON_PATH', 'api/v2.1/share-links/xyz1234567/dirents');
+// Should be fine, except if JMR decides to change the location of the SeaFile server... ;) - end with slash
+// define('SEAFILE_HOST', 'https://seafile.churchtools.de/');
 // switch Push on or off - without setting the push.inc was autodetected
 // define('ENABLE_PUSH', false);
+// the root directory of Churchtools - default is the parent of this
+// define('CT_ROOT_DIR', __DIR__.'/..');
+// Destination for the backup archives
+// define('BACKUP_DIR', __DIR__.'/../_BACKUP');
+// show more infos
+// define('DEBUG', false);
 
 ```
 
-Nun das Update-Skript im Root-Verzeichnis der ChurchTools Installation (neben `index.php, system, files, etc.`) ablegen und per Cronejob einmal am Tag (z.B. bei uns 4:00 Uhr) so aufrufen:
-<https://churchtools_domain.xyz/update.php?EUER_PASSWORT>
+Nun könnt ihr das script Cronejob einmal am Tag (z.B. bei uns 4:00 Uhr) oder bei bedarf manuell so aufrufen:
+<https://churchtools_domain.xyz/update/?EUER_PASSWORT>
 
 Die meisten Hosting-Provider bieten Cronjobs für ihre Kunden an.
 Wenn ihr keine Cronjobs anlegen könnt, könnt ihr auch einen kostenlosen externen Dienst wie https://www.cron-job.org/ dafür verwenden.

--- a/README.md
+++ b/README.md
@@ -30,15 +30,24 @@ Wenn ihr jetzt noch bei `define('SEAFILE_DIR', '/d/xyz1234567/');` den Pfad auf 
 (Ihr bekommt bei Updates per E-Mail einen Link zu einer SeaFile-Seite, die i.d.R. so aussieht: https://seafile.churchtools.de/d/xyz1234567/, kopiert davon einfach den hinteren Teil!) 
 
 ### Configuration mit separatem File
-Alternativ könnt ihr auch die Daten in eine extra Daten `update_config.php` im selben Verzeichnis packen, dann kann man ohne Probleme auch den Code des Updaters updaten:
+Alternativ könnt ihr auch die Daten in eine extra Daten `update_config.php` im selben Verzeichnis packen, dann kann man ohne Probleme auch den Code des Updaters updaten. `xyz1234567` müsst ihr jeweils mit dem Teil aus dem Link aus
+eurer Email ersetzen (Ihr bekommt bei Updates per E-Mail einen Link zu einer SeaFile-Seite, die i.d.R. so aussieht: https://seafile.churchtools.de/d/xyz1234567/, kopiert davon einfach den hinteren Teil zwischen den beiden `/`!) 
+
+
+**update_config.php:**
 ```php
 <?php
 // Put in your own password hash here
 define('HASH', 'PUT IN YOUR OWN HASH HERE');
-// Modify to correct seafile server URL here
-define('SEAFILE_DIR', '/d/xyz1234567/');
-// Should be fine, except if JMR decides to change the location of the SeaFile server... ;)
-define('SEAFILE_URL', 'https://seafile.churchtools.de/' . SEAFILE_DIR);
+// Modify to correct seafile server URL here - end with slash
+define('SEAFILE_DIR', 'd/xyz1234567/');
+// Should be fine, except if JMR decides to change the location of the SeaFile server... ;) - end with slash
+define('SEAFILE_HOST', 'https://seafile.churchtools.de/');
+// JsonPath to the file containing the file list
+define('SEAFILE_JSON_PATH', 'api/v2.1/share-links/xyz1234567/dirents');
+// switch Push on or off - without setting the push.inc was autodetected
+// define('ENABLE_PUSH', false);
+
 ```
 
 Nun das Update-Skript im Root-Verzeichnis der ChurchTools Installation (neben `index.php, system, files, etc.`) ablegen und per Cronejob einmal am Tag (z.B. bei uns 4:00 Uhr) so aufrufen:

--- a/createHash.php
+++ b/createHash.php
@@ -1,6 +1,0 @@
-<?php
-/**
-* Echos a bcrypt-encrypted password hash of the password passed in as query string
-*/
-
-echo password_hash($_SERVER['QUERY_STRING'], PASSWORD_BCRYPT, array('cost' => 12));

--- a/index.php
+++ b/index.php
@@ -1,25 +1,55 @@
 <?php
+// disable PHP timelimit
+set_time_limit(0);
+
 /**
  * ChurchTools - Auto Updater
  * @copyright: Copyright (c) 2016, Dennis Eisen & Michael Lux
  * @version  : 29.05.2016
  */
-
 header('Content-Type: text/plain; charset=utf-8');
 
 // optional, add your data in a separat file
-if (file_exists('update_config.php')) {
-    require 'update_config.php';
+if (file_exists('config.php')) {
+    require 'config.php';
 }
+// not configured - show config.php content with Hash
+if (!defined('HASH')) {
+    if (!empty($_SERVER['QUERY_STRING'])) {
+        $hash = password_hash($_SERVER['QUERY_STRING'], PASSWORD_BCRYPT, array('cost' => 12));
+        echo <<<EOF
+<?php
+// Put in your own password hash here
+define('HASH', '$hash');
+// Modify to correct seafile server URL here - end with slash
+define('SEAFILE_DIR', 'd/xyz1234567/');
+// JsonPath to the file containing the file list
+define('SEAFILE_JSON_PATH', 'api/v2.1/share-links/xyz1234567/dirents');
+// Should be fine, except if JMR decides to change the location of the SeaFile server... ;) - end with slash
+// define('SEAFILE_HOST', 'https://seafile.churchtools.de/');
+// switch Push on or off - without setting the push.inc was autodetected
+// define('ENABLE_PUSH', false);
+// the root directory of Churchtools - default is the parent of this
+// define('CT_ROOT_DIR', __DIR__.'/..');
+// Destination for the backup archives
+// define('BACKUP_DIR', __DIR__.'/../_BACKUP');
+// show more infos
+// define('DEBUG', false);
+EOF;
+    } else {
+        echo "ChurchTools AuotUpdater is unconfigured\n";
+        echo "*****************************************\n";
+        echo "To configure the auto updater, call this script /update/index.php?YOUR_OWN_SECRET_PASSORD and save the given data as config.php in your update directory to generate a secret hash and save it.";
+    }
+    die();
+}
+
+
 // Pushover and Pushbullet integration
-if ((!defined('ENABLE_PUSH') || ENABLE_PUSH) && file_exists('push.inc.php')) {
+if (defined('ENABLE_PUSH') && ENABLE_PUSH && file_exists('push.inc.php')) {
     require 'push.inc.php';
 }
 
-// Put in your own password hash here
-if (!defined('HASH')) {
-    define('HASH', '...');
-}
 // Modify to correct seafile server URL here
 if (!defined('SEAFILE_DIR')) {
     define('SEAFILE_DIR', 'd/.../');
@@ -31,6 +61,17 @@ if (!defined('SEAFILE_JSON_PATH')) {
 // Should be fine, except if JMR decides to change the location of the SeaFile server... ;)
 if (!defined('SEAFILE_HOST')) {
     define('SEAFILE_HOST', 'https://seafile.church.tools/');
+}
+// the root directory of Churchtools
+if (!defined('CT_ROOT_DIR')) {
+    define('CT_ROOT_DIR', __DIR__.'/..');
+}
+// Destination for the backup archives
+if (!defined('BACKUP_DIR')) {
+    define('BACKUP_DIR', __DIR__.'/../_BACKUP');
+}
+if (!defined('DEBUG')) {
+    define('DEBUG', false);
 }
 
 echo '### ChurchTools - Auto Updater ###', "\n\n";
@@ -107,14 +148,14 @@ function getDownloadURL() {
     foreach ($json['dirent_list'] as $item) {
         if ($item['is_dir'] == true || !preg_match('/churchtools-(3\..+?)(\.zip|\.tar\.gz)/', $item['file_name'], $matches))
             continue;
-        $version = $matches[1];
+        define('CT_VERSION', $matches[1]);
         $ext = $matches[2];
         $file = $item['file_path'];
         break; // don't look furhter, take first matched file
     }
 
     // dont't find a matching file?
-    if (!$version) {
+    if (!defined('CT_VERSION')) {
         if (function_exists('push')) {
             push('[Fehler] Download', "Kein gültiger ChurchTools 3 Download im FileList gefunden!"
                 . " <span style=\"color:red\">$url</span>", 1);
@@ -122,14 +163,16 @@ function getDownloadURL() {
         throw new Exception('No valid ChurchTools 3 download found in FileList!');
     }
 
+    $download_url = SEAFILE_HOST . SEAFILE_DIR . 'files/?p=' . $file . '&dl=1';
+    logMsg("find new Version " . CT_VERSION . " from $download_url");
     // Parse SeaFile timestamp
     $ts = DateTime::createFromFormat(DateTime::ATOM, $item['last_modified'])->getTimeStamp();
     // If SeaFile archive is older than modification date of constants.php, don't perform update
-    if (file_exists(__DIR__ . '/system/includes/constants.php') &&
-        filemtime(__DIR__ . '/system/includes/constants.php') > $ts) {
-        throw new Exception('ChurchTools is already up-to-date (' . $version . ')!');
+    if (file_exists(CT_ROOT_DIR . '/system/includes/constants.php') &&
+        filemtime(CT_ROOT_DIR . '/system/includes/constants.php') > $ts) {
+        throw new Exception('ChurchTools is already up-to-date (' . CT_VERSION . ')!');
     }
-    return [SEAFILE_HOST . SEAFILE_DIR . 'files/?p=' . $file . '&dl=1', $ext];
+    return [$download_url, $ext];
 }
 
 // Recursive deleting of directorys
@@ -141,13 +184,18 @@ function delTree($dir) {
     return rmdir($dir);
 }
 
-function makeBackup() {
+function makeBackup($dir = CT_ROOT_DIR, $dest_dir = BACKUP_DIR) {
+    logMsg("backup $dir to $dest_dir");
     // Root folder
-    $root = realpath(__DIR__);
+    $root = realpath($dir);
+    if (!is_dir($dest_dir))
+        mkdir($dest_dir);
 
     // Initialize archive object
     $zip = new ZipArchive();
-    $zip->open('backup_' . time() . '.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    $backup_file = $dest_dir . '/backup_' . time() . '.zip';
+    $zip->open($backup_file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    logMsg ("save backupfile " . basename($backup_file));
 
     // Backup systems folder
     if (file_exists($root . '/system')) {
@@ -172,8 +220,8 @@ function makeBackup() {
     }
 
     // Backup index.php
-    if (file_exists(__DIR__ . '/index.php')) {
-        $zip->addFile(__DIR__ . '/index.php', 'index.php');
+    if (file_exists($dir . '/index.php')) {
+        $zip->addFile($dir . '/index.php', 'index.php');
     }
 
     // Close ZIP, create archive
@@ -181,9 +229,10 @@ function makeBackup() {
 }
 
 // Extract 'system' and 'index.php' or trigger error
-function updateSystem($updateArchive) {
+function updateSystem($updateArchive, $target_dir = CT_ROOT_DIR) {
+    logMsg ("extract $updateArchive to $target_dir");
     $zip = new PharData($updateArchive);
-    $zip->extractTo(__DIR__);
+    $zip->extractTo($target_dir);
     $needle = 'churchtools';
     $dirName = null;
     foreach (scandir('phar:///' . $updateArchive) as $entry) {
@@ -191,34 +240,46 @@ function updateSystem($updateArchive) {
             $dirName = $entry;
         }
     }
+    logMsg ("   ..with dir $dirName");
 
-    if (!(file_exists(__DIR__ . '/' . $dirName) && is_dir(__DIR__ . '/' . $dirName))) {
+    if (!(file_exists($target_dir . '/' . $dirName) && is_dir($target_dir . '/' . $dirName))) {
         trigger_error('The ZIP archive does not contain directory "churchtools", or creation failed!',
             E_USER_ERROR);
         if (function_exists('push')) {
             push('[Fehler] ZIP', 'Das Verzeichnis "churchtools" fehlt im ZIP Archiv!', 1);
         }
+        // cleanup
+        if (is_dir($target_dir . '/' . $dirName))
+            delTree($target_dir . '/' . $dirName);
         throw new Exception('The ZIP archive does not contain directory "churchtools", or creation failed!');
     }
 
     // Check if directory system and index.php exist, if yes, rename them for backup
     makeBackup();
-    if (file_exists(__DIR__ . '/system')) {
-        delTree(__DIR__ . '/system');
+    logMsg ("delete old files and dirs");
+    if (file_exists($target_dir . '/system')) {
+        delTree($target_dir . '/system');
     }
-    if (file_exists(__DIR__ . '/index.php')) {
-        unlink(__DIR__ . '/index.php');
+    if (file_exists($target_dir . '/index.php')) {
+        unlink($target_dir . '/index.php');
     }
 
-    rename(__DIR__ . '/' . $dirName . '/system', __DIR__ . '/system');
-    rename(__DIR__ . '/' . $dirName . '/index.php', __DIR__ . '/index.php');
-    delTree(__DIR__ . '/' . $dirName);
+    logMsg ('move new files/dirs to ROOT');
+    rename($target_dir . '/' . $dirName . '/system', $target_dir . '/system');
+    rename($target_dir . '/' . $dirName . '/index.php', $target_dir . '/index.php');
+    delTree($target_dir . '/' . $dirName);
 
     if (function_exists('push')) {
         push('Update erfolgreich', 'Ein Update wurde erfolgreich installiert: <b>' . CT_VERSION . '</b>!');
     }
 
+    logMsg ("remove updateArchive");
     if (file_exists($updateArchive)) {
         unlink($updateArchive);
     }
+}
+
+function logMsg($msg) {
+    if (DEBUG)
+        echo $msg . "\n";
 }

--- a/update.php
+++ b/update.php
@@ -11,13 +11,23 @@ header('Content-Type: text/plain; charset=utf-8');
 if (file_exists('push.inc.php')) {
     require 'push.inc.php';
 }
+// optional, add your data in a separat file
+if (file_exists('update_config.php')) {
+    require 'update_config.php';
+}
 
 // Put in your own password hash here
-define('HASH',          '...');
+if (!defined('HASH')) {
+    define('HASH', '...');
+}
 // Modify to correct seafile server URL here
-define('SEAFILE_DIR',   'd/.../');
+if (!defined('SEAFILE_DIR')) {
+    define('SEAFILE_DIR', 'd/.../');
+}
 // Should be fine, except if JMR decides to change the location of the SeaFile server... ;)
-define('SEAFILE_URL',   'https://seafile.church.tools/' . SEAFILE_DIR);
+if (!defined('SEAFILE_URL')) {
+    define('SEAFILE_URL', 'https://seafile.church.tools/' . SEAFILE_DIR);
+}
 
 echo '### ChurchTools - Auto Updater ###', "\n\n";
 
@@ -33,8 +43,8 @@ register_shutdown_function(function () {
     }
 });
 
-$lockFile     = __DIR__ . '/ctupdate.lock';
-$ignoreLock   = false;
+$lockFile = __DIR__ . '/ctupdate.lock';
+$ignoreLock = false;
 $acquiredLock = false;
 try {
     // Check whether lock should be ignored because it's old (older than 10 minutes)
@@ -72,7 +82,7 @@ try {
             fclose($lock);
         }
         unlink($lockFile);
-    } else if (isset($lock)) {
+    } elseif (isset($lock)) {
         // Always close the file handle
         fclose($lock);
     }

--- a/update.php
+++ b/update.php
@@ -7,13 +7,13 @@
 
 header('Content-Type: text/plain; charset=utf-8');
 
-// Pushover and Pushbullet integration
-if (file_exists('push.inc.php')) {
-    require 'push.inc.php';
-}
 // optional, add your data in a separat file
 if (file_exists('update_config.php')) {
     require 'update_config.php';
+}
+// Pushover and Pushbullet integration
+if ((!defined('ENABLE_PUSH') || ENABLE_PUSH) && file_exists('push.inc.php')) {
+    require 'push.inc.php';
 }
 
 // Put in your own password hash here
@@ -24,9 +24,13 @@ if (!defined('HASH')) {
 if (!defined('SEAFILE_DIR')) {
     define('SEAFILE_DIR', 'd/.../');
 }
+// Modify to correct seafile server URL here
+if (!defined('SEAFILE_JSON_PATH')) {
+    define('SEAFILE_JSON_PATH', 'api/v2.1/share-links/.../dirents');
+}
 // Should be fine, except if JMR decides to change the location of the SeaFile server... ;)
-if (!defined('SEAFILE_URL')) {
-    define('SEAFILE_URL', 'https://seafile.church.tools/' . SEAFILE_DIR);
+if (!defined('SEAFILE_HOST')) {
+    define('SEAFILE_HOST', 'https://seafile.church.tools/');
 }
 
 echo '### ChurchTools - Auto Updater ###', "\n\n";
@@ -89,26 +93,43 @@ try {
 }
 
 // Build download link
-function getDownloadURL($url = SEAFILE_URL) {
-    $html = file_get_contents($url);
-    if (preg_match('#href="/' . SEAFILE_DIR . '(files/\?p=/churchtools-(3\..+?)(\.zip|\.tar\.gz))"'
-        . '.*?<time[^<]+title="([^"]+?)"#s', $html, $matches)) {
-        define('CT_VERSION', $matches[2]);
-        // Parse SeaFile timestamp
-        $ts = DateTime::createFromFormat(DateTime::RFC2822, $matches[4])->getTimeStamp();
-        // If SeaFile archive is older than modification date of constants.php, don't perform update
-        if (file_exists(__DIR__ . '/system/includes/constants.php') &&
-            filemtime(__DIR__ . '/system/includes/constants.php') > $ts) {
-            throw new Exception('ChurchTools is already up-to-date (' . $matches[2] . ')!');
-        }
-        return array($url . $matches[1] . '&dl=1', $matches[3]);
-    } else {
+function getDownloadURL() {
+    $json = json_decode(file_get_contents(SEAFILE_HOST . SEAFILE_JSON_PATH), true);
+    if (!$json || !isset($json['dirent_list'])) {
         if (function_exists('push')) {
-            push('[Fehler] Download', "Kein gültiger ChurchTools 3 Download im HTML gefunden!"
+            push('[Fehler] Download', "Kein gültiger ChurchTools 3 Download im JSON gefunden!"
                 . " <span style=\"color:red\">$url</span>", 1);
         }
-        throw new Exception('No valid ChurchTools 3 download found in HTML!');
+        throw new Exception('No valid ChurchTools 3 download found in JSON!');
     }
+    // find curchtools file in filelist
+    $matches = [];
+    foreach ($json['dirent_list'] as $item) {
+        if ($item['is_dir'] == true || !preg_match('/churchtools-(3\..+?)(\.zip|\.tar\.gz)/', $item['file_name'], $matches))
+            continue;
+        $version = $matches[1];
+        $ext = $matches[2];
+        $file = $item['file_path'];
+        break; // don't look furhter, take first matched file
+    }
+
+    // dont't find a matching file?
+    if (!$version) {
+        if (function_exists('push')) {
+            push('[Fehler] Download', "Kein gültiger ChurchTools 3 Download im FileList gefunden!"
+                . " <span style=\"color:red\">$url</span>", 1);
+        }
+        throw new Exception('No valid ChurchTools 3 download found in FileList!');
+    }
+
+    // Parse SeaFile timestamp
+    $ts = DateTime::createFromFormat(DateTime::ATOM, $item['last_modified'])->getTimeStamp();
+    // If SeaFile archive is older than modification date of constants.php, don't perform update
+    if (file_exists(__DIR__ . '/system/includes/constants.php') &&
+        filemtime(__DIR__ . '/system/includes/constants.php') > $ts) {
+        throw new Exception('ChurchTools is already up-to-date (' . $version . ')!');
+    }
+    return [SEAFILE_HOST . SEAFILE_DIR . 'files/?p=' . $file . '&dl=1', $ext];
 }
 
 // Recursive deleting of directorys


### PR DESCRIPTION
* rename update.php to index.php (sadly the diff shows as delete and add), so dont require /update/update.php
* move all configuration requirements to `config.php` which is not in git for better updates
* add CT_ROOT_DIR and BACKUP_DIR to customize the behaviour - default ist ../ and ../_BACKUP and the updater is in CT/update/
* add ENABLE_PUSH const as required to enable push, otherwise its disabled
* add DEBUG and logMsg() for more verbose output and debugging
* disable PHP timelimit - this could be an issue on some hosters
* remove createHash.php and auto generate Hash and show example `config.php` on the first run
* delete extracted dir on Exception, to prevent doing an manual remove if something failed
* update Readme